### PR TITLE
Re-implementing GitHub Packages

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,8 +15,12 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Build and publish (Bintray)
+    - name: Publish (Bintray)
       env:
         bintrayUser: ${{ secrets.bintrayUsername }}
         bintrayApiKey: ${{ secrets.bintrayApiKey }}
       run: ./gradlew bintrayUpload
+    - name: Publish (GitHub Packages)
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./gradlew publish

--- a/build.gradle
+++ b/build.gradle
@@ -73,4 +73,19 @@ publishing{
             artifact sourcesJar
         }
     }
+    repositories{
+        maven{
+            name = "GitHubPackages"
+            url = uri("https://maven.pkg.github.com/botblock/JavaBotBlockAPI")
+            credentials{
+                username = "botblock"
+                password = System.getenv("GITHUB_TOKEN")
+            }
+        }
+        publications{
+            gpr(MavenPublication){
+                from(components.java)
+            }
+        }
+    }
 }


### PR DESCRIPTION
I'll try to re-add GitHub packages as an option to publish the jars.
This would allow me to have more than one place to have new releases available if people for whatever reason don't want to use jcenter.