### PR TITLE
Update to new JDA Repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins{
     id 'com.github.johnrengelman.shadow' version '5.2.0'
 }
 
-def ver = new Version(major: 6, minor: 6, patch: 6)
+def ver = new Version(major: 6, minor: 7, patch: 0)
 
 allprojects {
     apply plugin: 'maven-publish'
@@ -87,6 +87,7 @@ allprojects {
     repositories {
         mavenCentral()
         jcenter()
+        maven { url = 'https://m2.dv8tion.net/releases' }
     }
     
     build {

--- a/core/src/main/java/org/botblock/javabotblockapi/core/Site.java
+++ b/core/src/main/java/org/botblock/javabotblockapi/core/Site.java
@@ -49,21 +49,6 @@ import java.util.List;
 public class Site{
     
     /**
-     * <a href="https://arcane-center.xyz" target="_blank">arcane-center.xyz</a>
-     * 
-     * <p>Supported methods:
-     * <ul>
-     *     <li>POST</li>
-     * </ul>
-     *
-     * @deprecated Website not responding.
-     */
-    @Deprecated
-    @DeprecatedSince(major = 6, minor = 6, patch = 6)
-    @PlannedRemoval(major = 6, minor = 6, patch = 8)
-    public static final Site ARCANE_CENTER_XYZ = new Site("arcane-center.xyz");
-    
-    /**
      * <a href="https://bladebotlist.xyz" target="_blank">bladebotlist.xyz</a>
      *
      * <p>Supported methods:
@@ -97,22 +82,6 @@ public class Site{
      * </ul>
      */
     public static final Site BOATSPACE_XYZ = new Site("boatspace.xyz", HttpMethod.GET, HttpMethod.POST);
-    
-    /**
-     * <a href="https://botsdatabase.com" target="_blank">botsdatabase.com</a>
-     *
-     * <p>Supported methods:
-     * <ul>
-     *     <li>GET</li>
-     *     <li>POST</li>
-     * </ul>
-     * 
-     * @deprecated Website not responding.
-     */
-    @Deprecated
-    @DeprecatedSince(major = 6, minor = 6, patch = 6)
-    @PlannedRemoval(major = 6, minor = 6, patch = 8)
-    public static final Site BOTSDATABASE_COM = new Site("botsdatabase.com");
     
     /**
      * <a href="https://bots.discordlabs.org" target="_blank">bots.discordlabs.org</a>

--- a/jda/build.gradle
+++ b/jda/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api(group: 'net.dv8tion', name: 'JDA', version: '4.2.0_247'){
+    api(group: 'net.dv8tion', name: 'JDA', version: '4.3.0_280'){
         exclude(module: 'opus-java')
     }
     implementation project(":core")


### PR DESCRIPTION
This release and newer will only support JDA versions which are distributed through their own repository (https://m2.dv8tion.net/releases)