### PR TITLE
Add check for discordlist.space tokens

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins{
     id 'com.github.johnrengelman.shadow' version '5.2.0'
 }
 
-def ver = new Version(major: 6, minor: 7, patch: 0)
+def ver = new Version(major: 6, minor: 7, patch: 1)
 
 allprojects {
     apply plugin: 'maven-publish'

--- a/core/src/main/java/org/botblock/javabotblockapi/core/BotBlockAPI.java
+++ b/core/src/main/java/org/botblock/javabotblockapi/core/BotBlockAPI.java
@@ -88,6 +88,10 @@ public class BotBlockAPI{
             CheckUtil.notEmpty(token, "Token");
             CheckUtil.condition(!site.supportsPost(), site.getName() + " does not support POST requests!");
             
+            // Discordlist.space requires the token to start with "Bot "
+            if(site.getName().equals("discordlist.space") && !token.startsWith("Bot "))
+                token = "Bot " + token;
+            
             tokens.put(site.getName(), token);
             return this;
         }
@@ -113,6 +117,10 @@ public class BotBlockAPI{
         public Builder addAuthToken(@Nonnull String site, @Nonnull String token){
             CheckUtil.notEmpty(site, "Site");
             CheckUtil.notEmpty(token, "Token");
+    
+            // Discordlist.space requires the token to start with "Bot "
+            if(site.equals("discordlist.space") && !token.startsWith("Bot "))
+                token = "Bot " + token;
             
             tokens.put(site, token);
             return this;

--- a/core/src/main/java/org/botblock/javabotblockapi/core/Info.java
+++ b/core/src/main/java/org/botblock/javabotblockapi/core/Info.java
@@ -35,11 +35,11 @@ public class Info{
     /**
      * Minor version of the Wrapper.
      */
-    public static final int MINOR = 6;
+    public static final int MINOR = 7;
     /**
      * Patch version of the Wrapper.
      */
-    public static final int PATCH = 6;
+    public static final int PATCH = 1;
     
     /**
      * Full version in the format {@code major.minor.patch}.

--- a/core/src/main/java/org/botblock/javabotblockapi/core/Site.java
+++ b/core/src/main/java/org/botblock/javabotblockapi/core/Site.java
@@ -18,9 +18,6 @@
 
 package org.botblock.javabotblockapi.core;
 
-import org.botblock.javabotblockapi.core.annotations.DeprecatedSince;
-import org.botblock.javabotblockapi.core.annotations.PlannedRemoval;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
Tokens for discordlist.space need to start with `Bot` so I've added a check to make sure one is present when setting a token for it.